### PR TITLE
MTTDOC-94 Preset added for sitemap generation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -257,6 +257,12 @@ module.exports = {
           customCss: require.resolve('./src/css/unity-custom.scss'),
           
         },
+        sitemap: {
+          cacheTime: 600 * 1000, // 600 sec - cache purge period
+          changefreq: 'weekly',
+          priority: 0.5,
+          trailingSlash: false,
+        },
       },
     ],
   ],


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [X] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->
Adds sitemap to doc site build for search. You can only see the file on a build server, or in /build on local. It's an under the covers tech item, nothing flashy. But helps search and meets a requirement for Algolia.
![image](https://user-images.githubusercontent.com/76010626/109887202-ed8e1a00-7c46-11eb-87aa-eaaf2f1bbfd1.png)

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->
MTTDOC-94
