### PR TITLE
Update error-messages.md

### DIFF
--- a/docs/troubleshooting/error-messages.md
+++ b/docs/troubleshooting/error-messages.md
@@ -5,11 +5,6 @@ title: MLAPI Error Messages
 
 Learn more about Unity error messages, including error collecting, issues that cause them, and how to handle.
 
-## Error Capturing
-
-Error messages are captured and returned through Unity Editor Diagnostics (required) and Roslyn Analyzers. ILPP occurs in Unity and returns error messages, which prevents you from building/playing your game (hard compile errors).
-Roslyn Analyzers provide immediate feedback within the IDE, without jumping back to Unity to let it compile with your new changes. Unity ILPP and Editor errors are the source of truth.
-
 ## NetworkObject errors
 
 **Error:** 
@@ -22,8 +17,19 @@ This exception should only occur if your scenes are not the same, for example if
 
 **Error:** 
 * Server: `[MLAPI] Only owner can invoke ServerRPC that is marked to require ownership`
-* Host: `KeyNotFoundException: The given key was not present in the dictionary.`
 
-The ServerRPC should only be used on the server. Make sure to add `isServer` check before calling.
+The ServerRPC should only be used on the server. Make sure to add `IsServer` check before calling.
 
-If the call is added correctly but still returns a `nullreferenceexception`, `NetworkManager.Singleton` may be returning `null`. Verify you created the `GameObject` with a `NetworkManager` component, which handles all initialization. `NetworkManager.Singleton` is a reference to a instance of the `NetworkManager` component.
+If the call is added correctly but still returns a `nullreferenceexception`, `NetworkManager.Singleton` may be returning `null`. Verify you have a `GameObject` with a `NetworkManager` component in your scene, which handles all initialization. `NetworkManager.Singleton` is a reference to a instance of the `NetworkManager` component.
+
+
+## Advanced
+
+:::caution
+Thit section contains advanced information about MLAPI.
+:::
+
+### Error Capturing
+
+Error messages are captured and returned through Unity Editor Diagnostics (required) and Roslyn Analyzers. ILPP occurs in Unity and returns error messages, which prevents you from building/playing your game (hard compile errors).
+Roslyn Analyzers provide immediate feedback within the IDE, without jumping back to Unity to let it compile with your new changes. Unity ILPP and Editor errors are the source of truth.


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
- Just some small correction to remove the dictionary key not found exception. Key not found is a generic c# exception which can happen at many places inside MLAPI and user code.
- I moved the paragraph about how the MLAPI error messaging internal works into a separate advanced section. This is not information which the average user needs. If I go to error-messages.md page I want to get more information about a specific error message I'm encountering in MLAPI. I don't want to learn how MLAPI works internally. I think we might need a better consistent way to mark advanced content like that.
- I'm a bit confused as to why we have MLAPI Error Messages and the Troubleshooting page. Right now they kind of do the same thing. (Both have deeper explanation for error messages)