### PR TITLE
GH #102: Fix RPC naming

### DIFF
--- a/docs/migration/migratingtomlapi.md
+++ b/docs/migration/migratingtomlapi.md
@@ -13,7 +13,7 @@ If you need help, contact us in the [Unity MLAPI Discord](https://discord.gg/buM
 
 Review the following limitations for upgrade and migrations from previous versions of MLAPI to Unity MLAPI:
 
-- Naming constraints may cause issues. UNet prefixed methods with `Cmd` or `Rpc`. MLAPI requires postfix. This may require either complicated multi-line regex to find and replace, or manual updates. For example, `CommandAttribute` has been renamed `ServerRPCAttribute` and `ClientRPCAttribute` has been renamed `ClientRPCAttribute`.
+- Naming constraints may cause issues. UNet prefixed methods with `Cmd` or `Rpc`. MLAPI requires postfix. This may require either complicated multi-line regex to find and replace, or manual updates. For example, `CommandAttribute` has been renamed `ServerRPCAttribute` and `ClientRPCAttribute`.
 - Errors for RPC postfix naming patterns do not show in your IDE. 
 - MLAPI RPCs do not support arrays yet.
 - Client and Server have separate representations in UNet. UNet has a number of callbacks that do not exist for MLAPI.

--- a/docs/migration/migratingtomlapi.md
+++ b/docs/migration/migratingtomlapi.md
@@ -13,7 +13,7 @@ If you need help, contact us in the [Unity MLAPI Discord](https://discord.gg/buM
 
 Review the following limitations for upgrade and migrations from previous versions of MLAPI to Unity MLAPI:
 
-- Naming constraints may cause issues. UNet prefixed methods with `Cmd` or `Rpc`. MLAPI requires postfix. This may require either complicated multi-line regex to find and replace, or manual updates. For example, `CommandAttribute` has been renamed `ServerRPCAttribute` and `ClientRPCAttribute`.
+- Naming constraints may cause issues. UNet prefixed methods with `Cmd` or `Rpc`. MLAPI requires postfix. This may require either complicated multi-line regex to find and replace, or manual updates. For example, `CommandAttribute` has been renamed `ServerRpcAttribute` and `ClientRPCAttribute` has been renamed `ClientRpcAttribute`.
 - Errors for RPC postfix naming patterns do not show in your IDE. 
 - MLAPI RPCs do not support arrays yet.
 - Client and Server have separate representations in UNet. UNet has a number of callbacks that do not exist for MLAPI.


### PR DESCRIPTION
Feedback for /docs/migration/migratingtomlapi.md #102 from user IsaiahKelly on typo on page

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Fixes typo on migration to MLAPI page


**Issue Number:** 
#102 

