### PR TITLE
Fixed Small Typo

### DIFF
--- a/docs/mlapi-api/MLAPI.Serialization.NetworkWriter.md
+++ b/docs/mlapi-api/MLAPI.Serialization.NetworkWriter.md
@@ -269,7 +269,7 @@ Write bits to stream.
 
 <div class="markdown level1 summary">
 
-Write s certain amount of bits to the stream.
+Write a certain amount of bits to the stream.
 
 </div>
 


### PR DESCRIPTION
**Select the type of change:**
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Fixed very small typo in WriteBits(UInt64, Int32) section of NetworkWriter documentation.

**Issue Number:** 
N/A

