### PR TITLE
fix multiplayer typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ For full building content, see [Building Locally](https://github.com/Unity-Techn
 
 ## Connect with Unity 
 
-Connect with the Unity Multitplayer team and community on the [MLAPI by Unity](http://discord.mlapi.network/) Discord using channel #documentation. You can also raise threads on the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/)
+Connect with the Unity Multiplayer team and community on the [MLAPI by Unity](http://discord.mlapi.network/) Discord using channel #documentation. You can also raise threads on the [Unity Multiplayer Forum](https://forum.unity.com/forums/multiplayer.26/)


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Fixes typo with "multiplayer" in connect with unity section.


**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->

