### PR TITLE
Fix install instructions for LTS

### DIFF
--- a/releases/samples/release-0-2-0.md
+++ b/releases/samples/release-0-2-0.md
@@ -15,6 +15,14 @@ The Boss Room: Small Scale Co-op Sample v0.2.0 release provides new sample code,
 Boss Room: Small Scale Co-op Sample always requires the latest version of Unity MLAPI. See [Unity MLAPI](../index.md) for more information on those features, fixes, and known issues.
 :::
 
+## [0.2.1] - 2021-05-27
+
+v0.2.1 is a hotfix for an Early Access release for Boss Room: Small Scale Co-op Sample.
+
+### Fixes
+
+* [GitHub 343](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/pull/343) - Fixed parameter exception when connecting to lobby caused by an old MLAPI version. This fix reverts the change until the package is updated.
+
 ## [0.2.0] - 2021-05-19
 
 ## New features

--- a/versioned_docs/version-0.1.0/migration/installation.md
+++ b/versioned_docs/version-0.1.0/migration/installation.md
@@ -13,10 +13,11 @@ To install MLAPI on Unity 2021.x, use the Unity Package Manager to add the packa
 1. Install [Git](https://git-scm.com/) if you do not have it installed on your PC. After installing Git, restart your system. A full restart is required to update for Git or you may receive an error adding packages.
 
 1. Open the Unity Package Manager by navigating to **Window** > **Package Manager** on Unity’s main menu.
-1. Click ![Add](/img/add.png) in the status bar and select **Add package by name...** (due to the package being experimental).
+<!-- 1. Click ![Add](/img/add.png) in the status bar and select **Add package by name...** (due to the package being experimental).
 
   ![Select Name Options](/img/install/install-name.png)
 
+Saving content till fixed
 1. Enter the MLAPI release package name (below) and click **Add**. You can click the Copy option in that codeblock and paste it in the Package Manager. The Package Manage auto-detects from the repository.
 
   ```
@@ -28,8 +29,19 @@ To install MLAPI on Unity 2021.x, use the Unity Package Manager to add the packa
   :::info How to Copy
   We recommend that you use the **Copy** function in the code block above to copy the URL as other methods may result in errors. Just hover and click.
   :::
+-->
+1. Click ![Add](/img/add.png) in the status bar and select **Add package from git URL...** (due to the package being experimental).
+1. Enter the Git URL to the MLAPI release package (below). You can click the Copy option in that codeblock and paste it in the Package Manager. <!--The Package Manage auto-detects from the repository.-->
 
-1. The package installs, shown as MLAPI Networking Library 0.1.0 with an Exp (experimental) label.
+  ```
+  https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#release/0.1.0
+  ```
+
+  :::info How to Copy
+  We recommend that you use the **Copy** function in the code block above to copy the URL as other methods may result in errors. Just hover and click.
+  :::
+
+1. Click **Add**. The package installs, shown as MLAPI Networking Library 0.1.0 with an Exp (experimental) label.
 
   ![Package Installed](/img/install/install-0-1-0-2021.png)
 
@@ -44,8 +56,7 @@ To install MLAPI on Unity versions 2019.4 and later and 2020.x, use the Unity Pa
 
   ![Select Git URL Option](/img/install/install-git.png)
 
-1. Select **Add package from git URL...**
-1. Enter the Git URL to the MLAPI release package (below). You can click the Copy option in that codeblock and paste it in the Package Manager. The Package Manage auto-detects from the repository.
+1. Enter the Git URL to the MLAPI release package (below). You can click the Copy option in that codeblock and paste it in the Package Manager. <!--The Package Manage auto-detects from the repository.-->
 
   ```
   https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#release/0.1.0

--- a/versioned_docs/version-0.1.0/migration/installation.md
+++ b/versioned_docs/version-0.1.0/migration/installation.md
@@ -17,9 +17,9 @@ To install MLAPI on Unity 2021.x, use the Unity Package Manager to add the packa
 
   ![Select Name Options](/img/install/install-name.png)
 
-1. Enter the Git URL to the MLAPI release package (below) and click **Add**. You can click the Copy option in that codeblock and paste it in the Package Manager. The Package Manage auto-detects from the repository.
+1. Enter the MLAPI release package name (below) and click **Add**. You can click the Copy option in that codeblock and paste it in the Package Manager. The Package Manage auto-detects from the repository.
 
-  ```html
+  ```
   com.unity.multiplayer.mlapi
   ```
 
@@ -47,8 +47,8 @@ To install MLAPI on Unity versions 2019.4 and later and 2020.x, use the Unity Pa
 1. Select **Add package from git URL...**
 1. Enter the Git URL to the MLAPI release package (below). You can click the Copy option in that codeblock and paste it in the Package Manager. The Package Manage auto-detects from the repository.
 
-  ```html
-  com.unity.multiplayer.mlapi
+  ```
+  https://github.com/Unity-Technologies/com.unity.multiplayer.mlapi.git?path=/com.unity.multiplayer.mlapi#release/0.1.0
   ```
 
   :::info How to Copy


### PR DESCRIPTION
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**

This PR fixes the install instructions for versions before 2021 by readding the git URL since there is no "Add by name" option.