### PR TITLE
docs: Docs page request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/page_request.md
+++ b/.github/ISSUE_TEMPLATE/page_request.md
@@ -1,0 +1,15 @@
+---
+name: Documentation Page Request
+about: Missing a docs page about a topic? Let us know!
+title: ''
+labels: 'docs-request, type:feature'
+assignees: 'Briancoughlin'
+
+---
+
+**What documentation page is missing?**
+Describe for which feature you are missing a documentation page.
+
+**(optional) Provide us with more details**
+- Have you just started using Netcode for GameObjects or are you already experienced with Netcode?
+- Which format would you prefer for this documentation page? (in-depth explanation of the feature / code tutorial / sample use-cases etc.)


### PR DESCRIPTION
**Purpose of the Pull Request:**
Adds an additional issue template for requesting a docs page. The issue will be automatically assigned to Brian and have the `docs-request` and `type:feature` tags.

