### PR TITLE
Fixed typo in gp_module_one.md

### DIFF
--- a/docs/tutorials/goldenpath_series/gp_module_one.md
+++ b/docs/tutorials/goldenpath_series/gp_module_one.md
@@ -34,7 +34,7 @@ import Createclone from '../../shared/_create_clone_goldenpath.md';
 
 ## Adding Scripts to Goldenpath
 
-This section will add some scripts to Goilden Path  which will contain the new features we will be covering in this module.
+This section will add some scripts to Golden Path  which will contain the new features we will be covering in this module.
 
 1. Click the **Assets** folder.
 1. Create a new Folder and call it **Scripts**.


### PR DESCRIPTION
fixed typo "Goilden" to "Golden"

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->
Fixes a small typo in line 37 "Goilden" to "Golden

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->

