### PR TITLE
Feedback goldenpath2 links clh

### DIFF
--- a/docs/tutorials/goldenpath_series/gp_module_two.md
+++ b/docs/tutorials/goldenpath_series/gp_module_two.md
@@ -112,7 +112,7 @@ Now we will test the Server-controlled Network Variable works as we intended.
 
 1. Select **File > Build and Run**. 
 1. Stop the player.
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn.  
 1. You should see the following in the console, showing that the server and client are sharing the variable:
 
@@ -186,7 +186,7 @@ Now we check that the Network Transform functions correctly.
 
 1. Select **File > Build and Run**. 
 1. Stop the player. 
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn. 
 1. You should see the player capsule moving in a circle on both the client and the server.
 
@@ -269,7 +269,7 @@ Now we will test that the client and server are both recieving the RPCs correctl
 
 1. Select **File > Build and Run**. 
 1. Stop the player.
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn.  
 1. In the console, you should expect to see the client and server sending RPC messages to each other. 
 1. The client kicks off the exchange in its `Update` call the first time with a counter value of 0.  

--- a/versioned_docs/version-0.1.0/tutorials/goldenpath_series/gp_module_two.md
+++ b/versioned_docs/version-0.1.0/tutorials/goldenpath_series/gp_module_two.md
@@ -112,7 +112,7 @@ Now we will test the Server-controlled Network Variable works as we intended.
 
 1. Select **File > Build and Run**. 
 1. Stop the player.
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn.  
 1. You should see the following in the console, showing that the server and client are sharing the variable:
 
@@ -186,7 +186,7 @@ Now we check that the Network Transform functions correctly.
 
 1. Select **File > Build and Run**. 
 1. Stop the player. 
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn. 
 1. You should see the player capsule moving in a circle on both the client and the server.
 
@@ -269,7 +269,7 @@ Now we will test that the client and server are both recieving the RPCs correctl
 
 1. Select **File > Build and Run**. 
 1. Stop the player.
-1. Launch the client and server together in a terminal as shown in [Testing the command line helper](#testing-the-command-line-helper). 
+1. Launch the client and server together in a terminal as shown in [Testing the command line helper](goldenpath_foundation_module.md#testing-the-command-line-helper). 
 1. After a brief delay, the client and server will spawn.  
 1. In the console, you should expect to see the client and server sending RPC messages to each other. 
 1. The client kicks off the exchange in its `Update` call the first time with a counter value of 0.  


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Fixing links in "Golden Path Module Two" for "Testing the command line helper" to point to the section in "Golden Path Foundation Module." Currently, these links point to a header that doesn't exist on that page. Fixed in both develop and v 0.1.0.


**Issue Number:** 
https://github.com/Unity-Technologies/com.unity.multiplayer.docs/issues/275

