### PR TITLE
Fix usage of BeginSend in transport docs

### DIFF
--- a/transport/pipelines-usage.md
+++ b/transport/pipelines-usage.md
@@ -47,7 +47,7 @@ public class Client
     public void SendMessage(NativeArray<byte> someData)
     {
         // Send using the pipeline created in Configure()
-        var writer = m_DriverHandle.BeginSend(m_Pipeline, m_ConnectionToServer);
+        m_DriverHandle.BeginSend(m_Pipeline, m_ConnectionToServer, out var writer);
         writer.WriteBytes(someData);
         m_DriverHandle.EndSend(writer);
     }
@@ -127,7 +127,7 @@ var reliableStageId = NetworkPipelineStageCollection.GetStageId(typeof(ReliableS
 m_ServerDriver.GetPipelineBuffers(serverPipe, reliableStageId, serverToClient, out var tmpReceiveBuffer, out var tmpSendBuffer, out var serverReliableBuffer);
 var serverReliableCtx = (ReliableUtility.SharedContext*) serverReliableBuffer.GetUnsafePtr();
 
-var strm = m_ServerDriver.BeginSend(serverPipe, serverToClient);
+m_ServerDriver.BeginSend(serverPipe, serverToClient, out var strm);
 m_ServerDriver.EndSend(strm);
 if (serverReliableCtx->errorCode != 0)
 {

--- a/transport/samples/clientbehaviour.cs.md
+++ b/transport/samples/clientbehaviour.cs.md
@@ -52,7 +52,7 @@ public class ClientBehaviour : MonoBehaviour
                 Debug.Log("We are now connected to the server");
 
                 uint value = 1;
-                var writer = m_Driver.BeginSend(m_Connection);
+                m_Driver.BeginSend(m_Connection, out var writer);
                 writer.WriteUInt(value);
                 m_Driver.EndSend(writer);
             }

--- a/transport/samples/jobifiedclientbehaviour.cs.md
+++ b/transport/samples/jobifiedclientbehaviour.cs.md
@@ -37,7 +37,7 @@ struct ClientUpdateJob : IJob
                 Debug.Log("We are now connected to the server");
 
                 uint value = 1;
-                var writer = driver.BeginSend(connection[0]);
+                driver.BeginSend(connection[0], out var writer);
                 writer.WriteUInt(value);
                 driver.EndSend(writer);
             }

--- a/transport/samples/jobifiedserverbehaviour.cs.md
+++ b/transport/samples/jobifiedserverbehaviour.cs.md
@@ -59,7 +59,7 @@ struct ServerUpdateJob : IJobParallelForDefer
                 Debug.Log("Got " + number + " from the Client adding + 2 to it.");
                 number +=2;
 
-                var writer = driver.BeginSend(connections[index]);
+                driver.BeginSend(connections[index], out var writer);
                 writer.WriteUInt(number);
                 driver.EndSend(writer);
             }

--- a/transport/samples/serverbehaviour.cs.md
+++ b/transport/samples/serverbehaviour.cs.md
@@ -72,7 +72,7 @@ public class ServerBehaviour : MonoBehaviour
                     Debug.Log("Got " + number + " from the Client adding + 2 to it.");
                     number +=2;
 
-                    var writer = m_Driver.BeginSend(NetworkPipeline.Null, m_Connections[i]);
+                    m_Driver.BeginSend(NetworkPipeline.Null, m_Connections[i], out var writer);
                     writer.WriteUInt(number);
                     m_Driver.EndSend(writer);
                 }

--- a/transport/workflow-client-server-jobs.md
+++ b/transport/workflow-client-server-jobs.md
@@ -58,7 +58,7 @@ public void Execute()
             Debug.Log("We are now connected to the server");
 
             var value = 1;
-            var writer = driver.BeginSend(connection[0]);
+            driver.BeginSend(connection[0], out var writer);
             writer.WriteUInt(value);
             driver.EndSend(writer);
         }
@@ -268,7 +268,7 @@ public void Execute(int index)
             Debug.Log("Got " + number + " from the Client adding + 2 to it.");
             number +=2;
 
-            var writer = driver.BeginSend(connections[index]);
+            driver.BeginSend(connections[index], out var writer);
             writer.WriteUInt(number);
             driver.EndSend(writer);
         }

--- a/transport/workflow-client-server.md
+++ b/transport/workflow-client-server.md
@@ -246,14 +246,14 @@ After you have written your updated number to your stream, you call the `EndSend
 ```csharp
     number +=2;
 
-    var writer = m_Driver.BeginSend(NetworkPipeline.Null, m_Connections[i]);
+    m_Driver.BeginSend(NetworkPipeline.Null, m_Connections[i], out var writer);
     writer.WriteUInt(number);
     m_Driver.EndSend(writer);
     }
 ```
 
 :::note
-We are `NetworkPipeline.Null`, to the `BeginSend` function. This way we say to the driver to use the unreliable pipeline to send our data. It is also possible to not specify a pipeline.
+We are passing `NetworkPipeline.Null` to the `BeginSend` function. This way we say to the driver to use the unreliable pipeline to send our data. It is also possible to not specify a pipeline.
 :::
 
 Finally, you need to handle the disconnect case. This is pretty straight forward, if you receive a disconnect message you need to reset that connection to a `default(NetworkConnection)`. As you might remember, the next time the `Update` loop runs you will clean up after yourself.
@@ -356,13 +356,13 @@ This event tells you that you have received a `ConnectionAccept` message and you
 In this case, the server that is listening on port `9000` on `NetworkEndPoint.LoopbackIpv4` is more commonly known as `127.0.0.1`.
 :::
 
-```
+```csharp
     if (cmd == NetworkEvent.Type.Connect)
     {
         Debug.Log("We are now connected to the server");
 
         uint value = 1;
-        var writer = m_Driver.BeginSend(m_Connection);
+        m_Driver.BeginSend(m_Connection, out var writer);
         writer.WriteUInt(value);
         m_Driver.EndSend(writer);
     }


### PR DESCRIPTION
**Select the type of change:**
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
The transport documentation was using an old usage of the `NetworkDriver.BeginSend` method (one that returned the `DataStreamWriter` directly rather than through an `out` parameter). That old usage is not supported anymore in version 1.0.0 of UTP, so users would not be able to follow the documentation and get a working example.

**Issue Number:** 
None.

