### PR TITLE
Remove confusing statement

### DIFF
--- a/versioned_docs/version-1.0.0/tutorials/helloworld/helloworldintro.md
+++ b/versioned_docs/version-1.0.0/tutorials/helloworld/helloworldintro.md
@@ -77,8 +77,7 @@ This section adds in a player object and spawns it for each connected player.
 1. Delete **Player** from scene.
 
   :::tip
-  We remove **Player**, because we will be using the network library to spawn the player. The library cannot track objects that start in the scene.
-  :::
+  We remove **Player**, because we will be using the network library to spawn the player.
 
 1. Select `NetworkManager`.
 1. Inside the `NetworkManager` component tab, locate the  `NetworkPrefabs` field. 


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
This statement is not exactly true and has been confusing for multiple users making them think we don't support scene objects. I think we can remove it to reduce confusion without affecting the tutorial.