### PR TITLE
Wrong github url for adding the package in Unity 2020.3

### DIFF
--- a/versioned_docs/version-1.0.0/migration/installation.md
+++ b/versioned_docs/version-1.0.0/migration/installation.md
@@ -50,7 +50,7 @@ To install Netcode on Unity versions 2020.3.x, use the Unity Package Manager pas
 1. Enter the Git URL to the Netcode release package (below). You can click the Copy option in that codeblock and paste it in the Package Manager.
 
   ```
-  com.unity.netcode.gameobjects
+  https://github.com/Unity-Technologies/com.unity.netcode.gameobjects.git
   ```
 
   :::info How to Copy


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions

**Purpose of the Pull Request:**
Fixing github url for adding the netcode for gameobjects in Unity 2020.3.x


