### PR TITLE
transport: Clarify behavior of reliable pipeline when full

### DIFF
--- a/transport/pipelines-usage.md
+++ b/transport/pipelines-usage.md
@@ -119,7 +119,7 @@ m_ServerDriver = NetworkDriver.Create(new ReliableUtility.Parameters { WindowSiz
 m_Pipeline = m_ServerDriver.CreatePipeline(typeof(ReliableSequencedPipelineStage));
 ```
 
-Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error and it will not be reliable (no guarantee of delivery). It's possible to check for such errors by checking the error code in the reliability internal state:
+Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error. It's possible to check for such errors by checking the error code in the reliability internal state:
 
 ```csharp
 // Get a reference to the internal state or shared context of the reliability

--- a/transport_versioned_docs/version-0.8.0/pipelines-usage.md
+++ b/transport_versioned_docs/version-0.8.0/pipelines-usage.md
@@ -119,7 +119,7 @@ m_ServerDriver = NetworkDriver.Create(new ReliableUtility.Parameters { WindowSiz
 m_Pipeline = m_ServerDriver.CreatePipeline(typeof(ReliableSequencedPipelineStage));
 ```
 
-Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error and it will not be reliable (no guarantee of delivery). It's possible to check for such errors by checking the error code in the reliability internal state:
+Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error. It's possible to check for such errors by checking the error code in the reliability internal state:
 
 ```csharp
 // Get a reference to the internal state or shared context of the reliability

--- a/transport_versioned_docs/version-1.0.0/pipelines-usage.md
+++ b/transport_versioned_docs/version-1.0.0/pipelines-usage.md
@@ -119,7 +119,7 @@ m_ServerDriver = NetworkDriver.Create(new ReliableUtility.Parameters { WindowSiz
 m_Pipeline = m_ServerDriver.CreatePipeline(typeof(ReliableSequencedPipelineStage));
 ```
 
-Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error and it will not be reliable (no guarantee of delivery). It's possible to check for such errors by checking the error code in the reliability internal state:
+Because only 32 packets can be tracked at a time there can't be more than 32 packets in flight at any one time, trying to send a 33rd packet will result in an error. It's possible to check for such errors by checking the error code in the reliability internal state:
 
 ```csharp
 // Get a reference to the internal state or shared context of the reliability


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Clarify how the reliable pipeline in UTP handles a send when the send window is already full. The phrasing could lead one (like me!) to believe that when the window is full, any further sends would still be done but unreliably. This is not how the pipeline works (it actually doesn't send anything and only generates an error).


**Issue Number:** 
None.

