### PR TITLE
Fix broken link to Dilmer video

### DIFF
--- a/versioned_docs/version-1.0.0/getting-started/about.md
+++ b/versioned_docs/version-1.0.0/getting-started/about.md
@@ -17,7 +17,7 @@ Netcode is a mid-level networking library built for the Unity game engine to abs
 
 | Core Concepts | Debugging | Learn More |
 | -- | -- | -- |
-| [Networking](../getting-started/connection-approval.md)<br/>[Components](../components/networkmanager.md)<br/>[Objects](../basics/object-spawning.md)<br/>[Messaging System](../advanced-topics/messaging-system.md)<br/>[Serialization](../advanced-topics/serialization/serialization-intro.md)<br/>[Scenes](../basics/scene-management.md) | [Logging](../basics/logging.md)<br/>[Troubleshooting](../troubleshooting/troubleshooting.md)<br/>[Error Messages](../troubleshooting/error-messages.md) | [References](../learn/index.md)<br/>[Boss Room](../learn/getting-started-boss-room.md)<br/>[Bite Size Samples](../learn/bitesize-introduction.md)<br/>[Dilmer Tutorials](../learn/dimer/dilmet-video.md)<br/>[FAQs](../learn/faq.md) |
+| [Networking](../getting-started/connection-approval.md)<br/>[Components](../components/networkmanager.md)<br/>[Objects](../basics/object-spawning.md)<br/>[Messaging System](../advanced-topics/messaging-system.md)<br/>[Serialization](../advanced-topics/serialization/serialization-intro.md)<br/>[Scenes](../basics/scene-management.md) | [Logging](../basics/logging.md)<br/>[Troubleshooting](../troubleshooting/troubleshooting.md)<br/>[Error Messages](../troubleshooting/error-messages.md) | [References](../learn/index.md)<br/>[Boss Room](../learn/getting-started-boss-room.md)<br/>[Bite Size Samples](../learn/bitesize-introduction.md)<br/>[Dilmer Tutorials](../learn/dilmer/dilmer-video.md)<br/>[FAQs](../learn/faq.md) |
 
 </div>
 


### PR DESCRIPTION
Typos in link to Dilmer’s tutorials caused a broken link. Fixed the typos, the link worked with a quick test.

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Typos in link to Dilmer’s tutorials caused a broken link. Fixed the typos, the link worked with a quick test. 


**Issue Number:** 
N/A

