### PR TITLE
feat: adding tip on increasing disconnect timeout when using breakpoints

### DIFF
--- a/docs/tutorials/testing/techniques_and_tricks_for_debugging_multiplayer_games.md
+++ b/docs/tutorials/testing/techniques_and_tricks_for_debugging_multiplayer_games.md
@@ -18,7 +18,7 @@ Below is a list of practices and techniques that we use daily when working on th
 
 Use ParrelSync to run separate editor instances for your Host/Server and Client.
  
-### Use debug drawing techniques extensively.
+### Use debug drawing techniques extensively
 
 Unity engine has two debug rendering APIs that are very useful for the purposes of multiplayer game debugging:
  - [Debug.DrawRay](https://docs.unity3d.com/ScriptReference/Debug.DrawRay.html)
@@ -98,6 +98,8 @@ Sometimes, despite us using good debug rendering and logging it's still hard to 
 
 The same applies to very high latencies (1000ms) - these stress the lag hiding techniques, allowing us to visualize what the different lag hiding techniques are doing.
 
-### Increase time before timeout when using breakpoints to debug a Client or Server
+### Using breakpoints to debug a Client or Server
 
-Using breakpoints is a very common way of debugging a game, but, as it pauses the game, it can result in the connection timing out if you stay too long in this mode. To avoid this, you can temporarily increase the timeout value. If you are using the [UTP adapter for Netcode](../../transport-api/introduction.md) you can edit the `DisconnectTimeout` field of the `UnityTransport` script used by your `NetworkManager`. However, make sure that you reset this value afterwards when you're no longer debugging.
+You can use breakpoints to debug a game, but your connection may time out if you stay too long in this mode. Since it pauses your game, you can temporarily increase the timeout value to avoid disconnecting. 
+
+If you are using the [UTP adapter for Netcode](../../transport-api/introduction.md) edit the `DisconnectTimeout` field of the `UnityTransport` script used by your `NetworkManager`. Make sure that you reset this value when you are no longer debugging.

--- a/docs/tutorials/testing/techniques_and_tricks_for_debugging_multiplayer_games.md
+++ b/docs/tutorials/testing/techniques_and_tricks_for_debugging_multiplayer_games.md
@@ -97,3 +97,7 @@ In debug builds it's a great idea to show the Peer ID and the current frame numb
 Sometimes, despite us using good debug rendering and logging it's still hard to understand what's going on even when going through the frames one by one. Increasing our FixedTimeStep setting to a ridiculous value (something as high as `0.2`) helps to have more time to really see what’s going on.
 
 The same applies to very high latencies (1000ms) - these stress the lag hiding techniques, allowing us to visualize what the different lag hiding techniques are doing.
+
+### Increase time before timeout when using breakpoints to debug a Client or Server
+
+Using breakpoints is a very common way of debugging a game, but, as it pauses the game, it can result in the connection timing out if you stay too long in this mode. To avoid this, you can temporarily increase the timeout value. If you are using the [UTP adapter for Netcode](../../transport-api/introduction.md) you can edit the `DisconnectTimeout` field of the `UnityTransport` script used by your `NetworkManager`. However, make sure that you reset this value afterwards when you're no longer debugging.


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Small Changes - Typos, formatting, slight revisions
- [x] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->
This PR adds a tip explaining how temporarily increasing the disconnect timeout value can help debugging when using breakpoints.

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->
[MTT-2560](https://jira.unity3d.com/browse/MTT-2560)

