### PR TITLE
Fix the code in the transport secure workflow example

### DIFF
--- a/transport/workflow-client-server-secure.md
+++ b/transport/workflow-client-server-secure.md
@@ -82,7 +82,7 @@ public static class SecureParameters
         public static FixedString4096Bytes MyGameClientCA = new FixedString4096Bytes(
 @"-----BEGIN CERTIFICATE-----
             ***   
- -----END CERTIFICATE-----"); // This should contain the content of myGameClientCA.pem 
+-----END CERTIFICATE-----"); // This should contain the content of myGameClientCA.pem 
  
         public static FixedString4096Bytes MyGameServerCertificate = new FixedString4096Bytes(
 @"-----BEGIN CERTIFICATE-----     


### PR DESCRIPTION
**Select the type of change:**
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**

Fixes the code in the transport secure workflow example. There's an extra space in the definition of the certificates that breaks the functionality in a non-obvious way.

**Issue Number:** 

None.