### PR TITLE
UTP: Avoid calling Dispose if objects are not created

### DIFF
--- a/transport/samples/jobifiedserverbehaviour.cs.md
+++ b/transport/samples/jobifiedserverbehaviour.cs.md
@@ -93,9 +93,12 @@ public class JobifiedServerBehaviour : MonoBehaviour
     public void OnDestroy()
     {
         // Make sure we run our jobs to completion before exiting.
-        ServerJobHandle.Complete();
-        m_Connections.Dispose();
-        m_Driver.Dispose();
+        if (m_Driver.IsCreated)
+        {
+            ServerJobHandle.Complete();
+            m_Connections.Dispose();
+            m_Driver.Dispose();
+        }
     }
 
     void Update ()

--- a/transport/samples/secureserverbehaviour.cs.md
+++ b/transport/samples/secureserverbehaviour.cs.md
@@ -14,11 +14,10 @@ public class SecureServerBehaviour : MonoBehaviour
 {
     public NetworkDriver m_Driver;
     private NativeList<NetworkConnection> m_Connections;
-    private NetworkSettings settings;
-    
     
     void Start ()
     {
+        var settings = new NetworkSettings();
         settings.WithSecureServerParameters(
             certificate: ref SecureParameters.MyGameServerCertificate,            // The content of the `myGameServerCertificate.pem`           
             privateKey: ref SecureParameters.MyGameServerPrivate                  // The content of `myGameServerPrivate.pem`
@@ -36,8 +35,11 @@ public class SecureServerBehaviour : MonoBehaviour
 
     public void OnDestroy()
     {
-        m_Driver.Dispose();
-        m_Connections.Dispose();
+        if (m_Driver.IsCreated)
+        {
+            m_Driver.Dispose();
+            m_Connections.Dispose();
+        }
     }
 
     void Update ()

--- a/transport/samples/serverbehaviour.cs.md
+++ b/transport/samples/serverbehaviour.cs.md
@@ -32,8 +32,11 @@ public class ServerBehaviour : MonoBehaviour
 
     public void OnDestroy()
     {
-        m_Driver.Dispose();
-        m_Connections.Dispose();
+        if (m_Driver.IsCreated)
+        {
+            m_Driver.Dispose();
+            m_Connections.Dispose();
+        }
     }
 
     void Update ()

--- a/transport/workflow-client-server-jobs.md
+++ b/transport/workflow-client-server-jobs.md
@@ -351,9 +351,12 @@ You need to remember to call `ServerJobHandle.Complete` in your `OnDestroy` meth
 public void OnDestroy()
 {
     // Make sure we run our jobs to completion before exiting.
-    ServerJobHandle.Complete();
-    m_Connections.Dispose();
-    m_Driver.Dispose();
+    if (m_Driver.IsCreated)
+    {
+        ServerJobHandle.Complete();
+        m_Connections.Dispose();
+        m_Driver.Dispose();
+    }
 }
 ```
 

--- a/transport/workflow-client-server.md
+++ b/transport/workflow-client-server.md
@@ -153,10 +153,15 @@ Add the following code to the `OnDestroy` method on your [MonoBehaviour](https:/
 ```csharp
 public void OnDestroy()
 {
-    m_Driver.Dispose();
-    m_Connections.Dispose();
+    if (m_Driver.IsCreated)
+    {
+        m_Driver.Dispose();
+        m_Connections.Dispose();
+    }
 }
 ```
+
+The check for `m_Driver.IsCreated` ensures we don't dispose of the memory if it hasn't been allocated (e.g. if the component is disabled).
 
 ### Server Update loop
 


### PR DESCRIPTION
**Select the type of change:**

- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**

Modify the UTP code samples to only call `Dispose` methods on objects that have been created. Native collections throw an exception if we dispose of them before they're created. In the code samples that's normally not the case, but it could happen if the server component is disabled (e.g. if toggling client/server functionality when testing with another build).

**Issue Number:** 

N/A