### PR TITLE
fix: removing outdated BR interpolation example and replacing it with a reference to NetworkTransform

### DIFF
--- a/docs/components/networktransform.md
+++ b/docs/components/networktransform.md
@@ -36,6 +36,9 @@ Check the `Interpolate` setting to enabled interpolation. Interpolation is enabl
 
 When `Interpolate` is disabled changes to the transform are applied immediately resulting in a less smooth position and more jitter.
 
+:::note
+The NetworkTransform component only interpolates client-side. For smoother movement on the host or server, users may want to implement interpolation server-side as well. While the server will not have the jitter caused by the network, some jitter can still happen locally, for example if movement is done in FixedUpdate.
+:::
 
 <figure>
 <ImageSwitcher 

--- a/docs/components/networktransform.md
+++ b/docs/components/networktransform.md
@@ -37,7 +37,7 @@ Check the `Interpolate` setting to enabled interpolation. Interpolation is enabl
 When `Interpolate` is disabled changes to the transform are applied immediately resulting in a less smooth position and more jitter.
 
 :::note
-The NetworkTransform component only interpolates client-side. For smoother movement on the host or server, users may want to implement interpolation server-side as well. While the server will not have the jitter caused by the network, some jitter can still happen locally, for example if movement is done in FixedUpdate.
+The NetworkTransform component only interpolates client-side. For smoother movement on the host or server, users may want to implement interpolation server-side as well. While the server will not have the jitter caused by the network, some stutter can still happen locally, for example if movement is done in FixedUpdate with a low physics update rate.
 :::
 
 <figure>

--- a/docs/learn/clientside-interpolation.md
+++ b/docs/learn/clientside-interpolation.md
@@ -36,3 +36,7 @@ An improvement that produces even smoother gameplay at the cost of even more add
 
 Snapshot Interpolation is not implemented in Netcode at this time.
 :::
+
+## Boss Room Example
+
+In the [Boss Room sample](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/), NetworkTransform components are used for client-side interpolation. Since transforms are updated in FixedUpdate, however, there is also some server-side interpolation that is needed on the host to smooth out movement. See [ClientProjectileVisualization](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/Scripts/Gameplay/GameplayObjects/ClientProjectileVisualization.cs) and [PositionLerper](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/Scripts/Utils/PositionLerper.cs) for an example of how it is done.

--- a/docs/learn/clientside-interpolation.md
+++ b/docs/learn/clientside-interpolation.md
@@ -27,75 +27,12 @@ In client-side Interpolation instead of just snapping objects to their positions
 
 Normally a client in a server-authoritative topology, barring any additional tricks and techniques, would be able to render state that is approximately half the Round Trip Time (RTT) behind the actual state of simulation on the server. In order for client-side interpolation to be able to work it needs to be somewhat behind (catching up to) the most recent state passed to us from the server. In effect, our latency would increase by our [Interpolation Period](../reference/glossary/ticks-and-update-rates#interpolation-period). In order to avoid stutter, we want that period to be less than the [Packet Sending Period](../reference/glossary/ticks-and-update-rates#packet-sending-period). When the client is done interpolating to the previous state, it would always have received a new state to repeat the process. 
 
-:::unity Future  Netcode for GameObjects (Netcode) Feature
+Client-side interpolation is implemented in Netcode for GameObjects (Netcode) in the [NetworkTransform](../components/networktransform.md) component.
+
+:::unity Future  Netcode Feature
 This implementation of Client-side Interpolation provides some improvement to the choppiness problem, but it does not completely solve the issues caused by jitter.
 
 An improvement that produces even smoother gameplay at the cost of even more added latency is Snapshot Interpolation, where instead of interpolating towards the most up-to-date state, we introduce a buffer that keeps several snapshots of incoming state and interpolates through them. This technique provides better handling of Jitter, but, again, it introduces slight additional latency on top of what we had in Clientside Interpolation.
 
 Snapshot Interpolation is not implemented in Netcode at this time.
 :::
-
-## Boss Room Example 
-
-:::unity
-This technique is implemented in the [Boss Room sample](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/). A brief implementation description is as follows (with further documentation available on the Boss Room GitHub page):
-:::
-
-Before reviewing into code, define the `GameObject` composition model for player characers, and similarly AI characters, inside Boss Room:
-
-* The first, a non-visual, `NetworkObject`: Contains both server and client `NetworkBehaviour` components, namely *ServerCharacterMovement.cs* and *ClientGenericMovement.cs*. We refer to this `GameObject` as "PC".
-* The second, a visual `GameObject`: Displays the character's model and play animations. This is the `GameObject` which performs client-side interpolation. We refer to this as "Graphics".
-
-### NetworkCharacterState
-
-We first take a look at *NetworkCharacterState.cs*, a `NetworkBehaviour` component attached to a "PC".
-
-```csharp reference
-https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/BossRoom/Scripts/Shared/Game/Entity/NetworkCharacterState.cs#L45-L55
-```
-
-It is a `NetworkBehaviour` that defines two `NetworkVariable`s: `NetworkPosition` and `NetworkRotationY`.
-These two `NetworkVariable`s are defined with default permissions, meaning that only the server is able to modify the values of these `NetworkVariables`.
-
-You will also notice that they're also initialized with a particular `SendChannel`, namely `MLAPI.Transports.NetworkChannel.PositionUpdate`.
-
-### ServerCharacterMovement
-
-Next look in *ServerCharacterMovement.cs* where these `NetworkVariable`s are modified on the server:
-
-```csharp reference
-https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/BossRoom/Scripts/Server/Game/Character/ServerCharacterMovement.cs#L150-L159
-```
-
-The first thing to point out is that this is done inside `FixedUpdate()` with Boss Room's `FixedTimestep` set to 0.02s. This setting can be found in **ProjectSettings** > **Time**. This is the maximum possible frequency of updates of position and rotation. We highlight this because a server will not send a `NetworkVariable` update if the value is unchanged.
-
-### Client-side Code
-
-Next take a look at client-side code, which interprets what to do with this `NetworkVariable` data.
-A PC's position and rotation are modified inside the `Update()` method of *ClientGenericMovement.cs*:
-
-```csharp reference
-https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/BossRoom/Scripts/Client/Game/Character/ClientGenericMovement.cs#L35-L48
-```
-
-This is what we refered to as a "dumb terminal". Position and rotation data are applied as quickly as the client can render them.
-"Graphics" smoothes the transition of valid position and rotation data. The *ClientCharacterVisualizaton.cs* component is attached to the "Graphics" `GameObject`. 
-
-The Graphics' transform is modified inside the `Update()` method of *ClientCharacterVisualizaton.cs*:
-
-```csharp reference
-https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/BossRoom/Scripts/Client/Game/Character/ClientCharacterVisualization.cs#L335-L353
-```
-
-Examine `VisualUtils.SmoothMove(...)`, which is a "Graphics" transform:
-
-```csharp reference
-https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop/blob/main/Assets/BossRoom/Scripts/Client/Game/Utils/VisualUtils.cs#L22-L64
-```
-
-The Graphics transform moves according to the following:
-
-* For position syncing, it moves in the direction of the PC transform by an amount that is proportional to the distance between the two transforms, until the positions are identical.
-* For rotation syncing, it rotates towards the PC transform by a minimum amount every frame, until the rotations are identical.
-
-As mentioned, these calculations introduce additional latency. However, interpolation is what effectively masks jitter and makes the player movement "feel" smooth.


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->
This PR removes the outdated example from Boss Room used to explain client-side interpolation and replaces it with a reference to the NetworkTransform documentation.

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->
None
