### PR TITLE
Completely removed Tools About page

### DIFF
--- a/sidebarsTools.js
+++ b/sidebarsTools.js
@@ -1,9 +1,5 @@
 module.exports = {
     "tools": [
-       /*/ {
-            "type": "doc",
-            "id": "about"
-        }, /*/
         {
             "type": "doc",
             "id": "install-tools"

--- a/tools/about.md
+++ b/tools/about.md
@@ -3,6 +3,6 @@ id: about
 title: Multiplayer Tools
 ---
 
-KEEP HIDDEN UNTIL THERE IS ENOUGH CONTENT TO BE USEFUL.
+KEEP HIDDEN UNTIL THERE IS ENOUGH CONTENT TO BE USEFUL. This has been completely removed from sidebars content because it still appeared even when commented out.
 
 This section includes content for Multiplayer Tools.


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Removing Tools About page completely from sidebars doc because it is showing up in a glitch even though it was commented out from the build. Notated that About doc as a reminder to include it back to the sidebars doc when it becomes a more useful page.

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->

