### PR TITLE
Delete About placeholder; comment out did not work

### DIFF
--- a/tools/about.md
+++ b/tools/about.md
@@ -1,8 +1,0 @@
----
-id: about
-title: Multiplayer Tools
----
-
-KEEP HIDDEN UNTIL THERE IS ENOUGH CONTENT TO BE USEFUL. This has been completely removed from sidebars content because it still appeared even when commented out.
-
-This section includes content for Multiplayer Tools.


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Completely removed Tools About page placeholder because commenting out and removing from sidebar did not work. Still somehow visible live.

**Issue Number:** 
<!-- Post the issue or ticket number addressed by the PR. -->

