### PR TITLE
temp fix to about tools 404

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,7 +117,7 @@ module.exports = {
                     docsPluginId: 'transport'
                 },
                 {
-                    to: 'about',
+                    to: 'install-tools',
                     label: 'Multiplayer Tools',
                     position: 'left',
                     docsPluginId: 'tools',


### PR DESCRIPTION
temp fix to about tools 404 - clicking the button will not direct to install-tools page while we don't have a about tools landing page.

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
temp fix to about tools 404 


**Issue Number:** 
N/A

