### PR TITLE
fixing infinite loop issue with RPC example

### DIFF
--- a/docs/tutorials/goldenpath_series/gp_module_two.md
+++ b/docs/tutorials/goldenpath_series/gp_module_two.md
@@ -180,7 +180,7 @@ public class RpcTest : NetworkBehaviour
 {
     public override void OnNetworkSpawn()
     {
-        if (IsClient)
+        if (!IsServer)
         {
             TestServerRpc(0);
         }


### PR DESCRIPTION
Since the Host is both a client and server and the server invokes RPCs locally, this was causing an infinite loop issue.

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
This fixes the infinite loop issue with the [Introducing Rpcs](https://docs-multiplayer.unity3d.com/netcode/current/tutorials/goldenpath_series/goldenpath_two/index.html#introducing-rpcs) code example when running a Host.


