### PR TITLE
Fix typo using backticks

### DIFF
--- a/docs/tutorials/helloworld.md
+++ b/docs/tutorials/helloworld.md
@@ -83,7 +83,7 @@ This section adds in a player object and spawns it for each connected player.
 ### Adding your scene to the build
 
   :::important
-  When 'Enable Scene Management' is enabled for the NetworkManager (allowing the server to control which scenes should be loaded for the clients), we must ensure that the current scene has been added to the build, otherwise, we will be unable to enter play mode. This option is enabled by default.
+  When `Enable Scene Management` is enabled for the NetworkManager (allowing the server to control which scenes should be loaded for the clients), we must ensure that the current scene has been added to the build, otherwise, we will be unable to enter play mode. This option is enabled by default.
   :::
 
 1. Click **File** > **Build Settings**, in the upper-left corner of the Unity window


### PR DESCRIPTION
Should also fix this important note
https://docs-multiplayer.unity3d.com/netcode/current/tutorials/helloworld#adding-your-scene-to-the-build

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->
It fixes a slight typo in which it wasn't properly seen as a quote using backticks.
