### PR TITLE
Chrispope fix broken link to client driven sample

### DIFF
--- a/docs/learn/bitesize/bitesize-introduction.md
+++ b/docs/learn/bitesize/bitesize-introduction.md
@@ -7,7 +7,7 @@ The Bitesize Samples repository provides a series of sample code as modules to u
 
 * [2D Space Shooter Sample](bitesize-spaceshooter.md) - Learn more about physics movement and status effects using Netcode `NetworkVariables` and `ObjectPooling`.
 * [Invaders Sample](bitesize-invaders.md) - Learn more about game flow, modes, unconventional movement networked, and a shared timer.
-* [Client Driven Sample](bitesize-clientdriven) - Learn more about Client driven movements, networked physics, spawning vs statically placed objects, object reparenting
+* [Client Driven Sample](bitesize-clientdriven.md) - Learn more about Client driven movements, networked physics, spawning vs statically placed objects, object reparenting
 
 ## Requirements
 

--- a/transport_versioned_docs/version-2.0.0/event-loop.md
+++ b/transport_versioned_docs/version-2.0.0/event-loop.md
@@ -1,6 +1,0 @@
----
-id: event-loop
-title: handling the event loop
----
-
-# Event loop

--- a/transport_versioned_sidebars/version-2.0.0-sidebars.json
+++ b/transport_versioned_sidebars/version-2.0.0-sidebars.json
@@ -33,12 +33,10 @@
                               {
                                   "type": "doc",
                                   "id": "version-2.0.0/minimal-workflow-ws"
-                              }]
-                      },
-                      {
-                          "type": "doc",
-                          "id": "version-2.0.0/event-loop"
-                      }]
+                              }
+                            ]
+                      }
+                    ]
               },
               {
                   "collapsed": true,


### PR DESCRIPTION
Fix broken link to client-driven sample.

Missing .md in link to client-driven bitesize docs page.

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Fix broken link, missing .md in link.

**Issue Number:** 
#797

