### PR TITLE
Updating install instructions

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -41,7 +41,8 @@ Use with caution:
 
 1. Open your **Unity Hub** and select the **Project** you are presently working on or create a **New Project**.
 1. From the menu bar, navigate to **Window** > **Package Manager**.
-1. Click the plus sign ![Add](/img/add.png) in the **Package Manager** status bar and select **Add package by name..**.
+1. When using 2021.3+ click the plus sign ![Add](/img/add.png) in the **Package Manager** status bar and select **Add package by name**. 
+1. If using 2020.3LTS there is no option to add by package name, instead click **Add package from git URL**.
 
  ![Package Installed](/img/install/addbyname.png)
 


### PR DESCRIPTION
Updating install instructions to consider the slight differences with the pkg manager between 2020 and 2021 engine versions. 2020.3 does not have an option for add by name. Details added to help users install when using Unity 2020.3.

**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Updating install instructions to consider the slight differences with the pkg manager between 2020 and 2021 engine versions. 2020.3 does not have an option for add by name. Details added to help users install when using Unity 2020.3.


**Issue Number:** 
https://github.com/Unity-Technologies/com.unity.multiplayer.docs/issues/779

