### PR TITLE
Update PR template with warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-## **WARNING**: Please make your PR against the `develop` branch.
-
+#### **WARNING**: Please make your PR against the `develop` branch.
+- - -
 **Select the type of change:**
 <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Small Changes - Typos, formatting, slight revisions


### PR DESCRIPTION
#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Adds a warning message to the PR template telling contributors to create PRs against `develop` instead of `main`. It's possible to change the default branch, but that might break some of our automation and branch protection rules.

**Issue Number:**
<!-- Post the issue or ticket number addressed by the PR. -->