### PR TITLE
update: in-scene parenting advanced, host rpc warning, and scene management correction

### DIFF
--- a/docs/advanced-topics/inscene_parenting_player.md
+++ b/docs/advanced-topics/inscene_parenting_player.md
@@ -21,7 +21,7 @@ Steps to reproduce the behavior:
 ## Solution:
 
 
-If you want to do this when a player has first connected and all `NetworkObjects` (in-scene placed and already dynamically spawned by the server-host) have been fully synchronized with the client then we would recommend using the `NetworkManager.SceneManager.OnSceneEvent` to trap for the `C2S_SyncComplete` event.
+If you want to do this when a player has first connected and all `NetworkObjects` (in-scene placed and already dynamically spawned by the server-host) have been fully synchronized with the client then we would recommend using the `NetworkManager.SceneManager.OnSceneEvent` to trap for the `SynchronizeComplete` event.
 
 Here is an example script that we recommend using to achieve this:
 
@@ -61,11 +61,11 @@ public class ParentPlayerToInSceneNetworkObject : NetworkBehaviour
         // OnSceneEvent is very useful for many things
         switch (sceneEvent.SceneEventType)
         {
-            // The C2S_SyncComplete event tells the server that a client-player has:
+            // The SceneEventType event tells the server that a client-player has:
             // 1.) Connected and Spawned
             // 2.) Loaded all scenes that were loaded on the server at the time of connecting
             // 3.) Synchronized (instantiated and spawned) all NetworkObjects in the network session
-            case SceneEventData.SceneEventTypes.C2S_SyncComplete:
+            case SceneEventType.SynchronizeComplete:
                 {
                     // As long as we are not the server-player
                     if (sceneEvent.ClientId != NetworkManager.LocalClientId)
@@ -85,4 +85,8 @@ You should place this script on your in-scene placed `NetworkObject` (i.e. the f
 
 :::note
 Remove any parenting code you might have had from your player prefab before using the above script. Depending upon your project's goals, you might be parenting all players under the same in-scene placed `NetworkObject` or you might intend to have each player parenting unique.  If you want each player to be parented under a unique in-scene placed `NetworkObject` then you will need to have the same number of in-scene placed `NetworkObject`s as your maximum allowed players per game session.  The above example will only parent all players under the same in-scene placed `NetworkObject`.  You could extend the above example by migrating the scene event code into an in-scene placed `NetworkObject` that manages the parenting of players (i,e. name it something like `PlayerSpawnManager`) as they connect, make the `SetPlayerParent` method public, and add all in-scene placed `NetworkObject`s to a public list of GameObjects that the `PlayerSpawnManager` will reference and assign player's to as they connect while also freeing in-scene placed `NetworkObject`s as players disconnect during a game session.
+:::
+
+:::important
+NGO v1.2 has a [known issue](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/2396) with parenting dynamically spawned `NetworkObjects` under in-scene placed `NetworkObjects`. This will be fixed in the next NGO update.
 :::

--- a/docs/advanced-topics/message-system/clientrpc.md
+++ b/docs/advanced-topics/message-system/clientrpc.md
@@ -61,7 +61,7 @@ PongClientRpc(somenumber, sometext); // This is clearly a ClientRpc call
 
 ## To Send to One Client, use ClientRpcSendParameters
 
-The following code provides an example of using `ClientRpcSendParameters`, which sends a `ClientRpc` to a specific client connections. The default Netcode for GameObjects's behavior is to broadcast to every single client.
+The following code provides an example of using `ClientRpcSendParameters`, which sends a `ClientRpc` to a specific client connection. _The default Netcode for GameObjects behavior is to broadcast to every single client_.
 
 ```csharp
 private void DoSomethingServerSide(int clientId)
@@ -112,8 +112,12 @@ The host is both a client and a server. If a host invokes a client RPC, it trigg
 <ImageSwitcher 
 lightImageSrc="/img/sequence_diagrams/RPCs/ClientRPCs_ClientHosts_CalledByClientHost.png?text=LightMode"
 darkImageSrc="/img/sequence_diagrams/RPCs/ClientRPCs_ClientHosts_CalledByClientHost_Dark.png?text=DarkMode"/>
- <figcaption>Hosts can invoke client RPCs on `NetworkObjects`. The RPC will be placed in the local queue. After a short delay, the client RPC executes on the host and all other clients. When a client receives a client RPC it's executed on that client's version of the same `NetworkObject`.</figcaption>
+ <figcaption>Hosts can invoke client RPCs on `NetworkObjects`. If broadcasting to all clients, the RPC will be immediately invoked on the host and placed in the local queue. At the end of the frame, the client RPC will be sent to the remote clients. When a remote client receives the client RPC it's executed on the client's local cloned instance of the same `NetworkObject`.</figcaption>
 </figure>
+
+:::warning
+When running as a host, RPCs are invoked immediately within the same stack as the method invoking the RPC. Since a host is both considered a server and a client, you should avoid design patterns where a ClientRpc invokes a ServerRpc that invokes the same ClientRpc as this can end up in a stack overflow (i.e. infinite recursion).
+:::
 
 See the [Boss Room RPC xamples](../../learn/bossroom/bossroom-actions).
 

--- a/docs/advanced-topics/message-system/serverrpc.md
+++ b/docs/advanced-topics/message-system/serverrpc.md
@@ -133,22 +133,26 @@ The following are a few timing diagrams to help provide additional visual contex
 <ImageSwitcher 
 lightImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs.png?text=LightMode"
 darkImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs_Dark.png?text=DarkMode"/>
-  <figcaption>Client can invoke a server RPC on a Network Object. The RPC will be placed in the local queue and then sent to the server, where it will be executed on the server version of the same Network Object.</figcaption>
+  <figcaption>A Client can invoke a server RPC on a `NetworkObject`. The RPC will be placed in the local queue and then sent to the server at the end of the frame. Upon receiving the server RPC, it is executed on the Server's instance of the same `NetworkObject`.</figcaption>
 </figure>
 
 <figure>
 <ImageSwitcher 
 lightImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs_ClientHosts_CalledByClient.png?text=LightMode"
 darkImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs_ClientHosts_CalledByClient_Dark.png?text=DarkMode"/>
-  <figcaption>Clients can invoke server RPCs on Client Hosts the same way they can invoke server RPCs on the regular servers: the RPC will be placed in the local queue and then sent to the Client Host, where it will be executed on the Client Host's version of the same Network Object.</figcaption>
+  <figcaption>Clients can invoke server RPCs on Hosts exactly like they can on a Server: the RPC will be placed in the local queue and sent to the Host at the end of the frame. Upon receiving the server RPC,  it will be executed on the Host's instance of the same `NetworkObject`.</figcaption>
 </figure>
 
 <figure>
 <ImageSwitcher 
 lightImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs_ClientHosts_CalledByClientHost.png?text=LightMode"
 darkImageSrc="/img/sequence_diagrams/RPCs/ServerRPCs_ClientHosts_CalledByClientHost_Dark.png?text=DarkMode"/>
-  <figcaption>When a server RPC is invoked by the Client Host, the RPC will be placed in a local queue and then executed on the Client Host after a short delay. The same happens for pure servers.</figcaption>
+  <figcaption>When a server RPC is invoked by a Host, the RPC is immediately executed.</figcaption>
 </figure>
+
+:::warning
+When running as a host, RPCs are invoked immediately within the same stack as the method invoking the RPC. Since a host is both considered a server and a client, you should avoid design patterns where a ClientRpc invokes a ServerRpc that invokes the same ClientRpc as this can end up in a stack overflow (i.e. infinite recursion).
+:::
 
 ## See Also
 

--- a/docs/basics/scenemanagement/using-networkscenemanager.md
+++ b/docs/basics/scenemanagement/using-networkscenemanager.md
@@ -36,9 +36,11 @@ The `NetworkSceneManager` lives within the `NetworkManager` and is instantiated 
   - The `NetworkSceneManager` is only instantiated when a `NetworkManager` is started.
 - As a server:
   -  Any scene you want synchronized with currently connected or late joining clients **must** be loaded via the `NetworkSceneManager`
-    - If you use the `UnityEngine.SceneManagement.SceneManager` during a netcode enabled game session, then those scenes will not be synchronized with currently connected or late joining clients.
-      - A "late joining client" is a client that joins a game session that has already been started and there are already one or more clients connected
-        - _All netcode aware objects spawned prior to a late joining client need to be synchronized with the late joining client._
+    - If you use the `UnityEngine.SceneManagement.SceneManager` during a netcode enabled game session, then those scenes will not be synchronized with currently connected clients.
+      - A "late joining client" is a client that joins a game session that has already been started and there are already one or more clients connected.
+        - _All netcode aware objects spawned prior to a late joining client will be synchronized with a late joining client._
+      - If you load a scene on the server-side using `UnityEngine.SceneManagement.SceneManager` then it will be synchronized with late joining clients unless you use server-side scene validation (see [Scene Validation](using-networkscenemanager.md#scene-validation)).
+        - _It is a best practice to use `NetworkSceneManager` when loading scenes _
   -  The server does not require any clients to be currently connected before it starts loading scenes via the `NetworkSceneManager`.
     - Any scene loaded via `NetworkSceneManager` will always default to being synchronized with clients.
       - _Scene validation is explained later in this document._
@@ -354,7 +356,7 @@ You might find yourself in a scenario where you just need to dynamically generat
   - For this example we would return false any time `VerifySceneBeforeLoading` was invoked with the scene name "WorldCollisionGeometry".
  
  :::caution
- This only works under the scenario where the dynamically generated scene is a server-host side only scene unless you write server-side code that sends enough information to a newly connected client in order to replicate the dynamically generated scene via RPC, a custom message, a `NetowrkVariable`, or an in-scene placed NetworkObject that is in a scene, other than the dynamically generated one, and contains a `NetworkBehaviour` component with an overridden `OnSynchronize` method that includes additional serializatoin information about how to construct the dynamically generated scene.  The limitation on this approach is that the scene should not contain already spawned `NetworkObject`s as those will not get automatically synchronized when a client first connects.
+ This only works under the scenario where the dynamically generated scene is a server-host side only scene unless you write server-side code that sends enough information to a newly connected client in order to replicate the dynamically generated scene via RPC, a custom message, a `NetworkVariable`, or an in-scene placed NetworkObject that is in a scene, other than the dynamically generated one, and contains a `NetworkBehaviour` component with an overridden `OnSynchronize` method that includes additional serialization information about how to construct the dynamically generated scene.  The limitation on this approach is that the scene should not contain already spawned `NetworkObject`s as those will not get automatically synchronized when a client first connects.
  :::
 
 ### What Next?


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Updating an outdated advanced in-scene parenting example.
Additional warning when using host and invoking RPCs from within RPCs
Clarified scene management documentation and removed incorrect usage guideline entry.

At the very end of [Issue 2377](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2377) a user calls out some incorrect documentation.
#731 
Also internal discussion about potential infinite recursive issue when running as a host with a ServerRpc that calls a ClientRpc which. in turn, can invoke the same ServerRpc.
