### PR TITLE
Typos in NetworkManager.md

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -35,8 +35,6 @@ Netcode supports the following versions:
 Netcode supports the following platforms:
 * Windows, MacOS, and Linux
 * iOS and Android
-* WebGL (requires NGO 1.2.0+ and UTP 2.0.0+). **Note**: Although NGO 1.2.0 introduces WebGL support, there's a bug in NGO 1.2.0 that impacts WebGL compatibility, so it's recommended to use NGO 1.3.0+.
-
 * XR platforms running on Windows, Android, and iOS operating systems
 * Most [**closed platforms**](https://unity.com/platform-installation), such as consoles. Contact us for more information about specific closed platforms.
   + When working with consoles (such as PlayStation, Xbox, or Nintendo Switch), there may be Netcode-specific policies you should be aware of while testing and before launching your game live. Refer to the console's internal documentation for more information. This content is typically protected by NDA.

--- a/docs/components/networkmanager.md
+++ b/docs/components/networkmanager.md
@@ -140,9 +140,9 @@ Both the client and the server can subscribe to the `NetworkManager.OnClientDisc
 - **Network Interruption**: The transport detects there is no longer a valid network connection.
 
 **When disconnect notifications are triggered:**
-- Clients aren'tified when they're disconnected by the server.
-- The server notified if the client side disconnects (that is, a player exits a game session)
-- Both the server and clients aren'tified when their network connection is disconnected (network interruption)
+- Clients are notified when they're disconnected by the server.
+- The server is notified if the client side disconnects (_i.e_ a player intentionally exits a game session using `NetworkManager.DisconnectClient`).
+- Both the server and clients are notified when their network connection is unexpectedly disconnected (network interruption).
 
 **Scenarios where the disconnect notification won't be triggered**:
 - When a server "logically" disconnects a client.


### PR DESCRIPTION
Couple of typos, possibly from an overenthusiastic search-and-replace?

You might want to check that I've correctly interpreted this.  The server and the client *are* both notified when a client unexpectedly disconnects, right?

#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->

**Issue Number:**
<!-- Post the issue or ticket number addressed by the PR. -->