### PR TITLE
Fix wrong word, onlky? only!

### DIFF
--- a/docs/basics/connection-approval.md
+++ b/docs/basics/connection-approval.md
@@ -177,7 +177,7 @@ There might be times when you want to specify an alternate player Prefab to use 
         {
             if (index > AlternatePlayerPrefabs.Count)
             {
-                Debug.LogError($"Trying to assign player Prefab index of {index} when there are onlky {AlternatePlayerPrefabs.Count} entries!");
+                Debug.LogError($"Trying to assign player Prefab index of {index} when there are only {AlternatePlayerPrefabs.Count} entries!");
                 return;
             }
             if (NetworkManager.IsListening || IsSpawned)
@@ -205,7 +205,7 @@ There might be times when you want to specify an alternate player Prefab to use 
             }
             else
             {
-                Debug.LogError($"Client provided player Prefab index of {playerPrefabIndex} when there are onlky {AlternatePlayerPrefabs.Count} entries!");
+                Debug.LogError($"Client provided player Prefab index of {playerPrefabIndex} when there are only {AlternatePlayerPrefabs.Count} entries!");
                 return;
             }
             // Continue filling out the response

--- a/versioned_docs/version-1.1.0/basics/connection-approval.md
+++ b/versioned_docs/version-1.1.0/basics/connection-approval.md
@@ -163,7 +163,7 @@ There might be times when you want to specify an alternate player Prefab to use 
         {
             if (index > AlternatePlayerPrefabs.Count)
             {
-                Debug.LogError($"Trying to assign player Prefab index of {index} when there are onlky {AlternatePlayerPrefabs.Count} entries!");
+                Debug.LogError($"Trying to assign player Prefab index of {index} when there are only {AlternatePlayerPrefabs.Count} entries!");
                 return;
             }
             if (NetworkManager.IsListening || IsSpawned)
@@ -191,7 +191,7 @@ There might be times when you want to specify an alternate player Prefab to use 
             }
             else
             {
-                Debug.LogError($"Client provided player Prefab index of {playerPrefabIndex} when there are onlky {AlternatePlayerPrefabs.Count} entries!");
+                Debug.LogError($"Client provided player Prefab index of {playerPrefabIndex} when there are only {AlternatePlayerPrefabs.Count} entries!");
                 return;
             }
             // Continue filling out the response


### PR DESCRIPTION
Fix wrong word, onlky? only!

#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**

Under: 

docs/basics/connection-approval.md 
line 180 and line 208:
Debug.LogError($"Trying to assign player Prefab index of {index} when there are onlky {AlternatePlayerPrefabs.Count} entries!"); 
 
Replace onlky with only:
line 180 and line 208:
Debug.LogError($"Trying to assign player Prefab index of {index} when there are only {AlternatePlayerPrefabs.Count} entries!"); 

And edit version-1.1.0 onlky to only too.

**Issue Number:**
None