### PR TITLE
Fix struct Interface Equal Infinity Loop, Overflow

### DIFF
--- a/docs/basics/networkvariable.md
+++ b/docs/basics/networkvariable.md
@@ -482,7 +482,7 @@ public struct AreaWeaponBooster : INetworkSerializable, System.IEquatable<AreaWe
 
     public bool Equals(AreaWeaponBooster other)
     {
-        return other.Equals(this) && Radius == other.Radius && Location == other.Location;
+        return ApplyWeaponBooster.Equals(other.ApplyWeaponBooster) && Radius == other.Radius && Location == other.Location;
     }
 }
 ```


### PR DESCRIPTION
We just check equal variable
public WeaponBooster ApplyWeaponBooster;

not self check equal
AreaWeaponBooster .Equal(AreaWeaponBooster )

#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->

**Issue Number:**
<!-- Post the issue or ticket number addressed by the PR. -->