### PR TITLE
Bumping nodejs from 16 -> 18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
          steps {
             sh 'curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -'
             sh 'echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list'
-            sh 'curl -fsSL https://deb.nodesource.com/setup_16.x | bash -'
+            sh 'curl -fsSL https://deb.nodesource.com/setup_18.x | bash -'
             sh 'apt-get update && apt-get install -y nodejs yarn'
          }
       }


### PR DESCRIPTION
#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [x] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
Bumping NodeJS to version 18 to try and resolve build issues on staging and prod.

**Issue Number:**
N/A