### PR TITLE
updating code samples that uses outdated version of CurrentPlayer.ReadOnlyTags

### DIFF
--- a/mppm/player-tags/target-instance.md
+++ b/mppm/player-tags/target-instance.md
@@ -21,6 +21,7 @@ This example uses [Netcode for GameObjects](https://docs-multiplayer.unity3d.com
 :::
 
 ```csharp
+using System.Linq;
 using Unity.Netcode;
 using UnityEngine;
 using Unity.Multiplayer.Playmode;

--- a/mppm/player-tags/target-network.md
+++ b/mppm/player-tags/target-network.md
@@ -17,6 +17,7 @@ This example uses the [Network Simulator](https://docs-multiplayer.unity3d.com/t
 ```csharp
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Unity.Multiplayer.Playmode;
 using Unity.Multiplayer.Tools.NetworkSimulator.Runtime;
@@ -29,11 +30,11 @@ public class NetworkSimulation : MonoBehaviour
                                gameObject.AddComponent<NetworkSimulator>();
 
         var connectionPreset = NetworkSimulatorPresets.None;
-        if (CurrentPlayer.ReadOnlyTags() == "FastNetwork")
+        if (CurrentPlayer.ReadOnlyTags().Contains("FastNetwork"))
         {
             connectionPreset = NetworkSimulatorPresets.HomeBroadband;
         }
-        else if (CurrentPlayer.ReadOnlyTags() == "SlowNetwork")
+        else if (CurrentPlayer.ReadOnlyTags().Contains("SlowNetwork"))
         {
             connectionPreset = NetworkSimulatorPresets.Mobile2_5G;
         }

--- a/mppm/player-tags/target-team.md
+++ b/mppm/player-tags/target-team.md
@@ -17,6 +17,7 @@ The following script automatically sets a [NetworkVariable](https://docs-multipl
 A Player with a `Red` tag automatically sets the `Team` NetworkVariable to `Red`. A Player with a `Blue` tag automatically sets the `Team` NetworkVariable to `Blue`.
 
 ```csharp
+using System.Linq;
 using Unity.Netcode;
 using UnityEngine;
 using Unity.Multiplayer.Playmode;


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
<!-- Describe what the PR fixes or adds. -->

Return value of [CurrentPlayer.ReadOnlyTags](https://docs.unity3d.com/Packages/com.unity.multiplayer.playmode@1.3/api/Unity.Multiplayer.Playmode.CurrentPlayer.html#Unity_Multiplayer_Playmode_CurrentPlayer_ReadOnlyTags) has been changed from `IReadOnlyCollection<string>`(in [Multiplayer Play mode 0.6.0](https://docs.unity3d.com/Packages/com.unity.multiplayer.playmode@0.6/api/Unity.Multiplayer.Playmode.CurrentPlayer.ReadOnlyTags.html#Unity_Multiplayer_Playmode_CurrentPlayer_ReadOnlyTags)) to `string[]` since 1.0.0. As `string[]` doesn't have `.Contains()` method, it should be adjusted.

I would like to ask few things:
+ I wonder if it was a valid decision to use `System.Linq`. If it's better to do in another way, I'll do so.
+ Is it better to update `mppm_versioned_docs/version-1.*` too?

**Issue Number:**
<!-- Post the issue or ticket number addressed by the PR. -->
Nothing.