### PR TITLE
fix: update NetworkVariable docs

### DIFF
--- a/docs/basics/networkvariable.md
+++ b/docs/basics/networkvariable.md
@@ -10,10 +10,10 @@ title: NetworkVariables
 * New clients joining the game (also referred to as late-joining clients)
 * All connected clients during the game
 
-When using a [distributed authority](../terms-concepts/distributed-authority.md) network topology, A `NetworkVariable` will ensure value synchronization is handled during:
+When using a [distributed authority](../terms-concepts/distributed-authority.md) network topology, A `NetworkVariable` ensures value synchronization is handled during:
 
 * Ownership changes of the associated NetworkObject
-* Object redistribution during client connection or disconnection.
+* Object redistribution during client connection or disconnection
 
 You can use `NetworkVariable` [permissions](#permissions) to control read and write access to `NetworkVariable`s. You can also create [custom `NetworkVariable`s](custom-networkvariables.md).
 
@@ -26,13 +26,13 @@ You can use `NetworkVariable` [permissions](#permissions) to control read and wr
 - A `NetworkVariable`'s value can only be set:
     - When initializing the property (either when it's declared or within the Awake method).
     - While the associated NetworkObject is spawned (upon being spawned or any time while it's still spawned).
-- A `NetworkVariable` cannot be defined with the `static` keyword. Variables defined with the static keyword have a lifetime that lasts for the entire runtime of an application, rather than the much shorter lifetime of a `GameObject`. This results in incorrect and invalid state management where a `NetworkVariable` will not behave as expected.
+- A `NetworkVariable` can't be defined with the `static` keyword. Variables defined with the static keyword have a lifetime that lasts for the entire runtime of an application, rather than the much shorter lifetime of a `GameObject`. This results in incorrect and invalid state management where `NetworkVariable`s don't behave as expected.
 
 ### Initializing a NetworkVariable
 
-When the associated NetworkObject of a `NetworkBehaviour` with `NetworkVariable` properties is spawned, the associated `NetworkVariable` will be initialized and associated with its associated `NetworkBehaviour`. When any new client connects, it's synchronized with the current value of the `NetworkVariable` before the `NetworkBehaviour.OnNetworkSpawn` is invoked.
+When a NetworkObject with an associated `NetworkBehaviour` with `NetworkVariable` properties is spawned, the `NetworkVariable` is initialized and associated with its relevant `NetworkBehaviour`. When any new client connects, it's synchronized with the current value of the `NetworkVariable` before the `NetworkBehaviour.OnNetworkSpawn` is invoked.
 
-A `NetworkVariable` will be initialized during the associated `NetworkBehaviour` initialization. The [Start](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/MonoBehaviour.Start.html) and `OnNetworkSpawn` methods are invoked based on the type of NetworkObject the `NetworkBehaviour` is associated with:
+`NetworkVariable`s are initialized during the associated `NetworkBehaviour` initialization. The [Start](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/MonoBehaviour.Start.html) and `OnNetworkSpawn` methods are invoked based on the type of NetworkObject the `NetworkBehaviour` is associated with:
 
 - In-scene placed: Since the instantiation occurs via the scene loading mechanism(s), the `Start` method is invoked before `OnNetworkSpawn`.
 - Dynamically spawned: Since `OnNetworkSpawn` is invoked immediately (that is, within the same relative call-stack) after instantiation, the `Start` method is invoked after `OnNetworkSpawn`.
@@ -49,7 +49,7 @@ You should only set the value of a `NetworkVariable` when first initializing it 
 
 ### Using a NetworkVariable
 
-After initialization, subscribing to the `NetworkVariable.OnValueChanged` event will notify connected clients of value changes. Clients must be subscribed to this event prior to the value being changed. Typically, clients should register for `NetworkVariable.OnValueChanged` within the `OnNetworkSpawn` method.
+After initialization, subscribing to the `NetworkVariable.OnValueChanged` event notifies connected clients of value changes. Clients must be subscribed to this event prior to the value being changed. Typically, clients should register for `NetworkVariable.OnValueChanged` within the `OnNetworkSpawn` method.
 
 Two parameters are passed to any `NetworkVariable.OnValueChanged` subscribed callback method:
 
@@ -165,7 +165,7 @@ The [synchronization and notification example](#synchronization-and-notification
 
 The `OnValueChanged` example shows a simple server-authoritative `NetworkVariable` being used to track the state of a door (that is, open or closed) using a non-ownership-based server RPC. With `RequireOwnership = false` any client can notify the server that it's performing an action on the door. Each time the door is used by a client, the `Door.ToggleServerRpc` is invoked and the server-side toggles the state of the door. When the `Door.State.Value` changes, all connected clients are synchronized to the (new) current `Value` and the `OnStateChanged` method is invoked locally on each client.
 
-It is important to note how [RPCs](../advanced-topics/message-system/rpc.md) can be used in tandem with `NetworkVariable` state. An `RPC` call is used in tandem with a `NetworkVariable`. The `RPC` handles instantaneous notification of state, while the `NetworkVariable` handles synchronization across clients of that state.
+It's important to note how [RPCs](../advanced-topics/message-system/rpc.md) can be used in tandem with `NetworkVariable` state. When an `RPC` call is used in tandem with a `NetworkVariable`, the `RPC` handles instantaneous notification of state, while the `NetworkVariable` handles synchronization across clients of that state.
 
 ```csharp
 public class Door : NetworkBehaviour

--- a/docs/basics/networkvariable.md
+++ b/docs/basics/networkvariable.md
@@ -5,14 +5,15 @@ title: NetworkVariables
 
 `NetworkVariable`s are a way of synchronizing properties between servers and clients in a persistent manner, unlike [RPCs](../advanced-topics/message-system/rpc.md) and [custom messages](../advanced-topics/message-system/custom-messages.md), which are one-off, point-in-time communications that aren't shared with any clients not connected at the time of sending. `NetworkVariable`s are session-mode agnostic and can be used with either a [client-server](../terms-concepts/client-server.md) or [distributed authority](../terms-concepts/distributed-authority.md) network topology.
 
-`NetworkVariable` is a wrapper of the stored value of type `T`, so you need to use the `NetworkVariable.Value` property to access the actual value being synchronized. A `NetworkVariable` is synchronized with:
+`NetworkVariable` is a wrapper of the stored value of type `T`, so you need to use the `NetworkVariable.Value` property to access the actual value being synchronized. A `NetworkVariable` handles value synchronization for:
 
 * New clients joining the game (also referred to as late-joining clients)
-    * When the associated NetworkObject of a `NetworkBehaviour` with `NetworkVariable` properties is spawned, any `NetworkVariable`'s current state (`Value`) is automatically synchronized on the client side.
-* Connected clients
-    * When a `NetworkVariable` value changes, all connected clients that subscribed to the `NetworkVariable.OnValueChanged` event (prior to the value being changed) are notified of the change. Two parameters are passed to any `NetworkVariable.OnValueChanged` subscribed callback method:
-        - First parameter (Previous): The previous value before the value was changed
-        - Second parameter (Current): The newly changed `NetworkVariable.Value`
+* All connected clients during the game
+
+When using a [distributed authority](../terms-concepts/distributed-authority.md) network topology, A `NetworkVariable` will ensure value synchronization is handled during:
+
+* Ownership changes of the associated NetworkObject
+* Object redistribution during client connection or disconnection.
 
 You can use `NetworkVariable` [permissions](#permissions) to control read and write access to `NetworkVariable`s. You can also create [custom `NetworkVariable`s](custom-networkvariables.md).
 
@@ -25,13 +26,16 @@ You can use `NetworkVariable` [permissions](#permissions) to control read and wr
 - A `NetworkVariable`'s value can only be set:
     - When initializing the property (either when it's declared or within the Awake method).
     - While the associated NetworkObject is spawned (upon being spawned or any time while it's still spawned).
+- A `NetworkVariable` cannot be defined with the `static` keyword. Variables defined with the static keyword have a lifetime that lasts for the entire runtime of an application, rather than the much shorter lifetime of a `GameObject`. This results in incorrect and invalid state management where a `NetworkVariable` will not behave as expected.
 
-###  Initializing a NetworkVariable
+### Initializing a NetworkVariable
 
-When a client first connects, it's synchronized with the current value of the `NetworkVariable`. Typically, clients should register for `NetworkVariable.OnValueChanged` within the `OnNetworkSpawn` method. A `NetworkBehaviour`'s `Start` and `OnNetworkSpawn` methods are invoked based on the type of NetworkObject the `NetworkBehaviour` is associated with:   
+When the associated NetworkObject of a `NetworkBehaviour` with `NetworkVariable` properties is spawned, the associated `NetworkVariable` will also be spawned.The `NetworkVariable`'s current state (`Value`) is automatically synchronized on the client side. When any new client connects, it's synchronized with the current value of the `NetworkVariable` before the `NetworkBehaviour.OnNetworkSpawn` is invoked.
+
+A `NetworkVariable` will be initialized during the associated `NetworkBehaviour` initialization. The [Start](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/MonoBehaviour.Start.html) and `OnNetworkSpawn` methods are invoked based on the type of NetworkObject the `NetworkBehaviour` is associated with:
 
 - In-scene placed: Since the instantiation occurs via the scene loading mechanism(s), the `Start` method is invoked before `OnNetworkSpawn`.
-- Dynamically spawned: Since `OnNetworkSpawn` is invoked immediately (that is, within the same relative call-stack) after instantiation, the `Start` method is invoked after `OnNetworkSpawn`.  
+- Dynamically spawned: Since `OnNetworkSpawn` is invoked immediately (that is, within the same relative call-stack) after instantiation, the `Start` method is invoked after `OnNetworkSpawn`.
 
 Typically, these methods are invoked at least one frame after the NetworkObject and associated `NetworkBehaviour` components are instantiated. The table below lists the event order for dynamically spawned and in-scene placed objects respectively.
 
@@ -43,8 +47,17 @@ Start               | OnNetworkSpawn
 
 You should only set the value of a `NetworkVariable` when first initializing it or if it's spawned. It isn't recommended to set a `NetworkVariable` when the associated NetworkObject isn't spawned.
 
+### Using a NetworkVariable
+
+After initialization, subscribing to the `NetworkVariable.OnValueChanged` event will notify connected clients of value changes. Clients must be subscribed to this event prior to the value being changed. Typically, clients should register for `NetworkVariable.OnValueChanged` within the `OnNetworkSpawn` method.
+
+Two parameters are passed to any `NetworkVariable.OnValueChanged` subscribed callback method:
+
+- First parameter (Previous): The previous value before the value was changed
+- Second parameter (Current): The newly changed `NetworkVariable.Value`
+
 :::tip
-If you need to initialize other components or objects based on a `NetworkVariable`'s initial synchronized state, then you can use a common method that's invoked on the client side within the `NetworkVariable.OnValueChanged` callback (if assigned) and `NetworkBehaviour.OnNetworkSpawn` method.
+If you need to update other components or objects based on the state of a `NetworkVariable`, then you can use a common method that's invoked within the  `NetworkBehaviour.OnNetworkSpawn` method and the `NetworkVariable.OnValueChanged` callback.
 :::
 
 ## Supported types
@@ -141,8 +154,8 @@ public class TestNetworkVariableSynchronization : NetworkBehaviour
  ```
 
 If you attach the above script to an in-scene placed NetworkObject, make a standalone build, run the standalone build as a host, and then connect to that host by entering Play Mode in the Editor, you can see (in the console output):
-- The client side `NetworkVariable` value is the same as the server when `NetworkBehaviour.OnNetworkSpawn` is invoked.  
-- The client detects any changes made to the `NetworkVariable` after the in-scene placed NetworkObject is spawned.  
+- The client side `NetworkVariable` value is the same as the server when `NetworkBehaviour.OnNetworkSpawn` is invoked.
+- The client detects any changes made to the `NetworkVariable` after the in-scene placed NetworkObject is spawned.
 
 This works the same way with dynamically spawned NetworkObjects.
 
@@ -599,7 +612,7 @@ public class TestFixedString : NetworkBehaviour
 
     public override void OnNetworkDespawn()
     {
-        m_TextString.OnValueChanged -= OnTextStringChanged;        
+        m_TextString.OnValueChanged -= OnTextStringChanged;
     }
 
     private void OnTextStringChanged(FixedString128Bytes previous, FixedString128Bytes current)
@@ -628,5 +641,5 @@ public class TestFixedString : NetworkBehaviour
 
 
 :::note
-The above example uses a pre-set list of strings to cycle through for example purposes only.  If you have a predefined set of text strings as part of your actual design then you would not want to use a FixedString to handle synchronizing the changes to `m_TextString`.  Instead, you would want to use a `uint` for the type `T` where the `uint` was the index of the string message to apply to `m_TextString`.  
+The above example uses a pre-set list of strings to cycle through for example purposes only.  If you have a predefined set of text strings as part of your actual design then you would not want to use a FixedString to handle synchronizing the changes to `m_TextString`.  Instead, you would want to use a `uint` for the type `T` where the `uint` was the index of the string message to apply to `m_TextString`.
 :::

--- a/docs/basics/networkvariable.md
+++ b/docs/basics/networkvariable.md
@@ -30,7 +30,7 @@ You can use `NetworkVariable` [permissions](#permissions) to control read and wr
 
 ### Initializing a NetworkVariable
 
-When the associated NetworkObject of a `NetworkBehaviour` with `NetworkVariable` properties is spawned, the associated `NetworkVariable` will also be spawned.The `NetworkVariable`'s current state (`Value`) is automatically synchronized on the client side. When any new client connects, it's synchronized with the current value of the `NetworkVariable` before the `NetworkBehaviour.OnNetworkSpawn` is invoked.
+When the associated NetworkObject of a `NetworkBehaviour` with `NetworkVariable` properties is spawned, the associated `NetworkVariable` will be initialized and associated with its associated `NetworkBehaviour`. When any new client connects, it's synchronized with the current value of the `NetworkVariable` before the `NetworkBehaviour.OnNetworkSpawn` is invoked.
 
 A `NetworkVariable` will be initialized during the associated `NetworkBehaviour` initialization. The [Start](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/MonoBehaviour.Start.html) and `OnNetworkSpawn` methods are invoked based on the type of NetworkObject the `NetworkBehaviour` is associated with:
 
@@ -164,6 +164,8 @@ This works the same way with dynamically spawned NetworkObjects.
 The [synchronization and notification example](#synchronization-and-notification-example) highlights the differences between synchronizing a `NetworkVariable` with newly-joining clients and notifying connected clients when a `NetworkVariable` changes, but it doesn't provide any concrete example usage.
 
 The `OnValueChanged` example shows a simple server-authoritative `NetworkVariable` being used to track the state of a door (that is, open or closed) using a non-ownership-based server RPC. With `RequireOwnership = false` any client can notify the server that it's performing an action on the door. Each time the door is used by a client, the `Door.ToggleServerRpc` is invoked and the server-side toggles the state of the door. When the `Door.State.Value` changes, all connected clients are synchronized to the (new) current `Value` and the `OnStateChanged` method is invoked locally on each client.
+
+It is important to note how [RPCs](../advanced-topics/message-system/rpc.md) can be used in tandem with `NetworkVariable` state. An `RPC` call is used in tandem with a `NetworkVariable`. The `RPC` handles instantaneous notification of state, while the `NetworkVariable` handles synchronization across clients of that state.
 
 ```csharp
 public class Door : NetworkBehaviour

--- a/docs/tutorials/get-started-with-ngo.md
+++ b/docs/tutorials/get-started-with-ngo.md
@@ -173,14 +173,14 @@ namespace HelloWorld
             GUILayout.EndArea();
         }
 
-        static void StartButtons()
+        void StartButtons()
         {
             if (GUILayout.Button("Host")) m_NetworkManager.StartHost();
             if (GUILayout.Button("Client")) m_NetworkManager.StartClient();
             if (GUILayout.Button("Server")) m_NetworkManager.StartServer();
         }
 
-        static void StatusLabels()
+        void StatusLabels()
         {
             var mode = m_NetworkManager.IsHost ?
                 "Host" : m_NetworkManager.IsServer ? "Server" : "Client";
@@ -190,7 +190,7 @@ namespace HelloWorld
             GUILayout.Label("Mode: " + mode);
         }
 
-        static void SubmitNewPosition()
+        void SubmitNewPosition()
         {
             if (GUILayout.Button(m_NetworkManager.IsServer ? "Move" : "Request Position Change"))
             {
@@ -220,14 +220,14 @@ In your Hello World project, you created a NetworkManager by adding the pre-crea
 The `HelloWorldManager.cs` script accomplishes this menu within the `StartButtons().` After you select a button, the `StatusLabels()`method adds a label on-screen to display which mode you have selected. This helps distinguish Game view windows from each other when testing your multiplayer game.
 
 ```csharp
-       static void StartButtons()
+        void StartButtons()
         {
             if (GUILayout.Button("Host")) m_NetworkManager.StartHost();
             if (GUILayout.Button("Client")) m_NetworkManager.StartClient();
             if (GUILayout.Button("Server")) m_NetworkManager.StartServer();
         }
 
-        static void StatusLabels()
+        void StatusLabels()
         {
             var mode = m_NetworkManager.IsHost ?
                 "Host" : m_NetworkManager.IsServer ? "Server" : "Client";
@@ -390,7 +390,7 @@ namespace HelloWorld
             Position.Value = randomPosition;
         }
 
-        static Vector3 GetRandomPositionOnPlane()
+        Vector3 GetRandomPositionOnPlane()
         {
             return new Vector3(Random.Range(-3f, 3f), 1f, Random.Range(-3f, 3f));
         }
@@ -416,7 +416,7 @@ public class HelloWorldPlayer : NetworkBehaviour
 For multiplayer games, every object runs on at least two machines: player one and player two. Because of this, you need to ensure both machines have the same behavior and have the correct information about the object. One of the instances that come into play then is to understand how the Player moves. Only one player controls how the Player object moves. The following code enforces this by validating if the machine running the code is the player's owner.
 
 ```csharp
-       public override void OnNetworkSpawn()
+        public override void OnNetworkSpawn()
         {
             if (IsOwner)
             {
@@ -478,7 +478,7 @@ The `Rpc` sets the position NetworkVariable on the server's instance of the play
 The server instance of the player modifies the `Position` `NetworkVariable` through the `Rpc`. If the player is a client, it must apply the position locally inside the `Update` loop. (Since the two values are the same on the server, the server can run the same logic with no side effects, but you could also add `if(IsClient)` here.)
 
 ```csharp
-       void Update()
+        void Update()
         {
             transform.position = Position.Value;
         }
@@ -487,7 +487,7 @@ The server instance of the player modifies the `Position` `NetworkVariable` thro
 Because the `HelloWorldPlayer.cs` script handles the position NetworkVariable, the `HelloWorldManager.cs` script can define the contents of `SubmitNewPosition()`.
 
 ```csharp
-       static void SubmitNewPosition()
+        void SubmitNewPosition()
         {
             if (GUILayout.Button(m_NetworkManager.IsServer ? "Move" : "Request Position Change"))
             {

--- a/docs/tutorials/get-started-with-ngo.md
+++ b/docs/tutorials/get-started-with-ngo.md
@@ -173,14 +173,14 @@ namespace HelloWorld
             GUILayout.EndArea();
         }
 
-        void StartButtons()
+        static void StartButtons()
         {
             if (GUILayout.Button("Host")) m_NetworkManager.StartHost();
             if (GUILayout.Button("Client")) m_NetworkManager.StartClient();
             if (GUILayout.Button("Server")) m_NetworkManager.StartServer();
         }
 
-        void StatusLabels()
+        static void StatusLabels()
         {
             var mode = m_NetworkManager.IsHost ?
                 "Host" : m_NetworkManager.IsServer ? "Server" : "Client";
@@ -190,7 +190,7 @@ namespace HelloWorld
             GUILayout.Label("Mode: " + mode);
         }
 
-        void SubmitNewPosition()
+        static void SubmitNewPosition()
         {
             if (GUILayout.Button(m_NetworkManager.IsServer ? "Move" : "Request Position Change"))
             {
@@ -220,14 +220,14 @@ In your Hello World project, you created a NetworkManager by adding the pre-crea
 The `HelloWorldManager.cs` script accomplishes this menu within the `StartButtons().` After you select a button, the `StatusLabels()`method adds a label on-screen to display which mode you have selected. This helps distinguish Game view windows from each other when testing your multiplayer game.
 
 ```csharp
-        void StartButtons()
+       static void StartButtons()
         {
             if (GUILayout.Button("Host")) m_NetworkManager.StartHost();
             if (GUILayout.Button("Client")) m_NetworkManager.StartClient();
             if (GUILayout.Button("Server")) m_NetworkManager.StartServer();
         }
 
-        void StatusLabels()
+        static void StatusLabels()
         {
             var mode = m_NetworkManager.IsHost ?
                 "Host" : m_NetworkManager.IsServer ? "Server" : "Client";
@@ -390,7 +390,7 @@ namespace HelloWorld
             Position.Value = randomPosition;
         }
 
-        Vector3 GetRandomPositionOnPlane()
+        static Vector3 GetRandomPositionOnPlane()
         {
             return new Vector3(Random.Range(-3f, 3f), 1f, Random.Range(-3f, 3f));
         }
@@ -416,7 +416,7 @@ public class HelloWorldPlayer : NetworkBehaviour
 For multiplayer games, every object runs on at least two machines: player one and player two. Because of this, you need to ensure both machines have the same behavior and have the correct information about the object. One of the instances that come into play then is to understand how the Player moves. Only one player controls how the Player object moves. The following code enforces this by validating if the machine running the code is the player's owner.
 
 ```csharp
-        public override void OnNetworkSpawn()
+       public override void OnNetworkSpawn()
         {
             if (IsOwner)
             {
@@ -478,7 +478,7 @@ The `Rpc` sets the position NetworkVariable on the server's instance of the play
 The server instance of the player modifies the `Position` `NetworkVariable` through the `Rpc`. If the player is a client, it must apply the position locally inside the `Update` loop. (Since the two values are the same on the server, the server can run the same logic with no side effects, but you could also add `if(IsClient)` here.)
 
 ```csharp
-        void Update()
+       void Update()
         {
             transform.position = Position.Value;
         }
@@ -487,7 +487,7 @@ The server instance of the player modifies the `Position` `NetworkVariable` thro
 Because the `HelloWorldPlayer.cs` script handles the position NetworkVariable, the `HelloWorldManager.cs` script can define the contents of `SubmitNewPosition()`.
 
 ```csharp
-        void SubmitNewPosition()
+       static void SubmitNewPosition()
         {
             if (GUILayout.Button(m_NetworkManager.IsServer ? "Move" : "Request Position Change"))
             {


### PR DESCRIPTION
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
 - Update NetworkVariable docs
     - Add documentation static that `NetworkVariable`s should not be defined as `static`
     - Separate and expand on `NetworkVariable` initialization and usage to try clarify expected usage and behaviour of `NetworkBehaviour.OnNetworkSpawn` vs `NetworkVariable.OnValueChanged`
     - Add notes on `NetworkVariable` and distributed authority

**Issue Number:**
<!-- Post the issue or ticket number addressed by the PR. -->