### PR TITLE
update: ownership permissions clarity about client-server

### DIFF
--- a/docs/basics/ownership.md
+++ b/docs/basics/ownership.md
@@ -19,9 +19,9 @@ When another player joins, as in the diagram below, authority over distributable
 
 ![Distributed authority new client](/img/distributed-authority-new-client.jpg)
 
-### Ownership permission settings
+### Ownership permission settings (Distributed Authority Only)
 
-The following ownership permission settings, defined by `NetworkObject.OwnershipStatus`, are only available when running in distributed authority mode:
+The following ownership permission settings, defined by `NetworkObject.OwnershipStatus`, will only take effect when using a distributed authority network topology:
 
 * `None`: Ownership of this NetworkObject is considered static and can't be redistributed, requested, or transferred (a Player would have this, for example).
 * `Distributable`: Ownership of this NetworkObject is automatically redistributed when a client joins or leaves, as long as ownership is not locked or a request is pending.
@@ -30,6 +30,13 @@ The following ownership permission settings, defined by `NetworkObject.Ownership
 * `SessionOwner`: This NetworkObject is always owned by the [session owner](../terms-concepts/distributed-authority.md#session-ownership) and can't be transferred or distributed. If the session owner changes, this NetworkObject is automatically transferred to the new session owner.
 
 You can also use `NetworkObject.SetOwnershipLock` to lock and unlock the permission settings of a NetworkObject for a period of time, preventing ownership changes on a temporary basis.
+
+::: warning
+
+The ownership permissions will become visible when the Multiplayer Services SDK package is installed and you are inspecting a `NetworkObject` within the editor. The ownership permissions will have no impact when using a client-server network topology since the server always has authority. In order for the ownership permissions to be utilized, you must be using a distributed authority network topology.
+
+:::
+
 
 ## Checking for authority
 


### PR DESCRIPTION
Adding additional warning and information regarding ownership permissions only being taken into consideration when using a distributed authority network topology.

#### **WARNING**: Please make your PR against the `develop` branch.
- - -
**Select the type of change:**
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Small Changes - Typos, formatting, slight revisions
- [ ] New Content - New features, sections, pages, tutorials
- [ ] Site and Tools - Updates, maintenance, and new packages for the site and Docusaurus

**Purpose of the Pull Request:**
To address user confusion regarding when ownership permissions are used.

**Issue Number:**
NGO PR-[3470](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/3470)